### PR TITLE
feat: support SplitDNS via dns.Manager for userspace mode [no issue]

### DIFF
--- a/cmd/tailscaled/tailscaled.go
+++ b/cmd/tailscaled/tailscaled.go
@@ -577,6 +577,8 @@ func getLocalBackend(ctx context.Context, logf logger.Logf, logID logid.PublicID
 		}
 	}
 	if socksListener != nil || httpProxyListener != nil {
+		dialer.UserDialCustomResolver = dns.Quad100Resolver(ctx, sys.DNSManager.Get())
+
 		var addrs []string
 		if httpProxyListener != nil {
 			hs := &http.Server{Handler: httpProxyHandler(dialer.UserDial)}

--- a/net/dns/quad100.go
+++ b/net/dns/quad100.go
@@ -1,0 +1,85 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package dns
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+)
+
+type Quad100conn struct {
+	Ctx        context.Context
+	DnsManager *Manager
+
+	rbuf bytes.Buffer
+}
+
+var (
+	_ net.Conn       = (*Quad100conn)(nil)
+	_ net.PacketConn = (*Quad100conn)(nil) // be a PacketConn to change net.Resolver semantics
+)
+
+func (*Quad100conn) Close() error                       { return nil }
+func (*Quad100conn) LocalAddr() net.Addr                { return todoAddr{} }
+func (*Quad100conn) RemoteAddr() net.Addr               { return todoAddr{} }
+func (*Quad100conn) SetDeadline(t time.Time) error      { return nil }
+func (*Quad100conn) SetReadDeadline(t time.Time) error  { return nil }
+func (*Quad100conn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (c *Quad100conn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	return c.Write(p)
+}
+
+func (c *Quad100conn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	n, err = c.Read(p)
+	return n, todoAddr{}, err
+}
+
+func (c *Quad100conn) Read(p []byte) (n int, err error) {
+	return c.rbuf.Read(p)
+}
+
+func (c *Quad100conn) Write(packet []byte) (n int, err error) {
+	pkt, err := c.DnsManager.Query(c.Ctx, packet, "tcp", netip.AddrPort{})
+	if err != nil {
+		return 0, err
+	}
+	c.rbuf.Write(pkt)
+	return len(packet), nil
+}
+
+type todoAddr struct{}
+
+func (todoAddr) Network() string { return "unused" }
+func (todoAddr) String() string  { return "unused-todoAddr" }
+
+// Quad100Resolver sets up a DNS resolver that uses the Quad100Conn to send DNS
+// queries to MagicDNS.
+func Quad100Resolver(ctx context.Context, mgr *Manager) func(host string) (netip.Addr, error) {
+	return func(host string) (netip.Addr, error) {
+		var r net.Resolver
+		r.PreferGo = true
+		r.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+			return &Quad100conn{
+				Ctx:        ctx,
+				DnsManager: mgr,
+			}, nil
+		}
+
+		ips, err := r.LookupIP(ctx, "ip4", host)
+		if err != nil {
+			mgr.logf("dns lookup err: %v", err)
+			return netip.Addr{}, err
+		}
+		if len(ips) == 0 {
+			return netip.Addr{}, fmt.Errorf("DNS lookup returned no results for %q", host)
+		}
+		ip, _ := netip.AddrFromSlice(ips[0])
+		return ip, nil
+	}
+}

--- a/net/dns/quad100_test.go
+++ b/net/dns/quad100_test.go
@@ -1,0 +1,113 @@
+package dns
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	dns "golang.org/x/net/dns/dnsmessage"
+	"tailscale.com/health"
+	"tailscale.com/net/netmon"
+	"tailscale.com/net/tsdial"
+	"tailscale.com/util/dnsname"
+)
+
+func TestQuad100Conn(t *testing.T) {
+	f := fakeOSConfigurator{
+		SplitDNS: true,
+		BaseConfig: OSConfig{
+			Nameservers:   mustIPs("8.8.8.8"),
+			SearchDomains: fqdns("coffee.shop"),
+		},
+	}
+	m := NewManager(t.Logf, &f, new(health.Tracker), tsdial.NewDialer(netmon.NewStatic()), nil, nil, "")
+	m.resolver.TestOnlySetHook(f.SetResolver)
+	m.Set(Config{
+		Hosts: hosts(
+			"dave.ts.net.", "1.2.3.4",
+			"matt.ts.net.", "2.3.4.5"),
+		Routes:        upstreams("ts.net", ""),
+		SearchDomains: fqdns("tailscale.com", "universe.tf"),
+	})
+	defer m.Down()
+
+	q100 := &Quad100conn{
+		Ctx:        context.Background(),
+		DnsManager: m,
+	}
+	defer q100.Close()
+
+	var b []byte
+	domain := dnsname.FQDN("matt.ts.net.")
+
+	// Send a query
+	b = mkDNSRequest(domain, dns.TypeA, addEDNS)
+	_, err := q100.Write(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := make([]byte, 100)
+	if _, err := q100.Read(resp); err != nil {
+		t.Fatalf("reading data: %v", err)
+	}
+
+	var parser dns.Parser
+	if _, err := parser.Start(resp); err != nil {
+		t.Errorf("parser.Start() failed: %v", err)
+	}
+	_, err = parser.Question()
+	if err != nil {
+		t.Errorf("parser.Question(): %v", err)
+	}
+	if err := parser.SkipAllQuestions(); err != nil {
+		t.Errorf("parser.SkipAllQuestions(): %v", err)
+	}
+	ah, err := parser.AnswerHeader()
+	if err != nil {
+		t.Errorf("parser.AnswerHeader(): %v", err)
+	}
+	if ah.Type != dns.TypeA {
+		t.Errorf("unexpected answer type: got %v, want %v", ah.Type, dns.TypeA)
+	}
+	res, err := parser.AResource()
+	if err != nil {
+		t.Errorf("parser.AResource(): %v", err)
+	}
+	if net.IP(res.A[:]).String() != "2.3.4.5" {
+		t.Fatalf("dns query did not return expected result")
+	}
+
+}
+
+func TestQuad100Resolver(t *testing.T) {
+	f := fakeOSConfigurator{
+		SplitDNS: true,
+		BaseConfig: OSConfig{
+			Nameservers:   mustIPs("8.8.8.8"),
+			SearchDomains: fqdns("coffee.shop"),
+		},
+	}
+	m := NewManager(t.Logf, &f, new(health.Tracker), tsdial.NewDialer(netmon.NewStatic()), nil, nil, "")
+	m.resolver.TestOnlySetHook(f.SetResolver)
+	m.Set(Config{
+		Hosts: hosts(
+			"dave.ts.net.", "1.2.3.4",
+			"matt.ts.net.", "2.3.4.5"),
+		Routes:        upstreams("ts.net", ""),
+		SearchDomains: fqdns("tailscale.com", "universe.tf"),
+	})
+	defer m.Down()
+
+	resolver := Quad100Resolver(context.Background(), m)
+
+	ip, err := resolver("matt.ts.net")
+	if err != nil {
+		t.Errorf("could not resolve host: %v", err)
+	}
+
+	if ip.String() != "2.3.4.5" {
+		t.Fatalf("dns query did not return expected result")
+	}
+
+}


### PR DESCRIPTION
### Context

Updates #4677
Updates #9619

### Solution

- Add a Quad100conn for the DNS resolver. This uses the dns.Manager to perform the resolution and a fake IO interface for it.
- Add a UserDialCustomResolver to Dialer so we can override the IP resolution in UserDial, which is used by proxy handlers, to use the aforementioned Quad100conn
- Update the dns Forwarder to use UserDial instead so it can reach into the tailnet
- Change Dialer.UserDial to use the quad100 resolver after MagicDNS
